### PR TITLE
changing combobox dropdown calculation

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -25,6 +25,9 @@ import {
   getCaretDownButtonStyles
 } from './ComboBox.styles';
 import {
+  IComboBoxStyles,
+} from './ComboBox.types';
+import {
   IComboBoxClassNames,
   getClassNames,
   getComboBoxOptionClassNames
@@ -255,7 +258,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     let setWidth = isOpen ? (this._comboBoxWrapper.clientWidth - 2) + 'px' : undefined;
 
     this._classNames = getClassNames(
-      getStyles(theme!, customStyles, setWidth),
+      getStyles(theme!, customStyles),
       className!,
       !!isOpen,
       !!disabled,
@@ -800,6 +803,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       onRenderLowerContent = this._onRenderLowerContent
     } = props;
 
+    const dropdownWidth = (this.props.styles) ? this.props.styles.dropdownWidth : 0;
+
     return (
       <Callout
         isBeakVisible={ false }
@@ -812,6 +817,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         target={ this._comboBoxWrapper }
         onDismiss={ this._onDismiss }
         setInitialFocus={ false }
+        calloutWidth={ dropdownWidth || this._comboBoxWrapper.clientWidth }
       >
         <div className={ this._classNames.optionsContainerWrapper } ref={ this._resolveRef('_comboBoxMenu') }>
           { (onRenderList as any)({ ...props }, this._onRenderList) }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -209,6 +209,12 @@ export interface IComboBoxStyles {
    * Styles for a divider in the options.
    */
   divider: IStyle;
+
+  /**
+  * Custom width for dropdown. If value is 0, width of the input field is used.
+  * @default 0
+  */
+  dropdownWidth?: number;
 }
 
 export interface IComboBoxOptionStyles extends IButtonStyles {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #3400
https://github.com/OfficeDev/office-ui-fabric-react/issues/3400

#### Description of changes

Change the combobox dropdown width calculation the same way with dropdown width calculation, so that the scrollbar in combobox doens't overflow
#### Focus areas to test
- Click on combobox
Expected
- the scrollbar should be aligned at the end of the target element.
