### PR TITLE
Remove flex column on the container

### DIFF
--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.Style.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.Style.ts
@@ -61,7 +61,7 @@ export function getDateAndTimePickerStyle(props: IDatePickerStyleProps): IDatePi
         height: '100%',
         display: 'flex',
         minWidth: responsiveMode! <= ResponsiveMode.small ? '9rem' : '18rem',
-        flexDirection: responsiveMode! <= ResponsiveMode.small ? 'column' : 'row'
+        flexDirection: 'row'
       }],
     dateContainerChildDiv: {
     },


### PR DESCRIPTION
Removing flex column from the container. Now it stays as flex row in all instances.

There are IE11 bugs preventing flex column from working in some scenarios and flex row from working in other scenarios.
The workarounds are mutually exclusive, and therefore a container cannot resolve both issues if it switches between row and column.